### PR TITLE
Avoid using global variables in some tests, add tests for FE contexts

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,7 +17,7 @@
         "react-dom": "^18.2.0",
         "react-helmet": "^6.1.0",
         "react-hot-toast": "^2.4.1",
-        "react-icons": "^5.5.0",
+        "react-icons": "~5.4.0",
         "react-router-dom": "^6.22.0",
         "react-scripts": "5.0.1",
         "react-toastify": "^10.0.4",
@@ -22252,9 +22252,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
-      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
     "react-hot-toast": "^2.4.1",
-    "react-icons": "^5.5.0",
+    "react-icons": "~5.4.0",
     "react-router-dom": "^6.22.0",
     "react-scripts": "5.0.1",
     "react-toastify": "^10.0.4",

--- a/client/src/context/auth.test.tsx
+++ b/client/src/context/auth.test.tsx
@@ -1,0 +1,73 @@
+import { act, render, screen } from "@testing-library/react";
+import { AuthProvider, useAuth } from "./auth";
+
+// Helper to set up a test component using useAuth
+function TestComponent() {
+  const [auth, setAuth] = useAuth();
+  return (
+    <div>
+      <span data-testid="user">{String(auth.user)}</span>
+      <span data-testid="token">{auth.token}</span>
+      <button onClick={() => setAuth({ user: "testuser", token: "abc123" })}>
+        Update
+      </button>
+    </div>
+  );
+}
+
+describe("AuthProvider and useAuth", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.resetAllMocks();
+  });
+
+  test("provides default auth state", () => {
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    );
+    expect(screen.getByTestId("user").textContent).toBe("null");
+    expect(screen.getByTestId("token").textContent).toBe("");
+  });
+
+  test("updates auth state via setAuth", () => {
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    );
+    act(() => {
+      screen.getByText("Update").click();
+    });
+    expect(screen.getByTestId("user").textContent).toBe("testuser");
+    expect(screen.getByTestId("token").textContent).toBe("abc123");
+  });
+
+  test("loads auth state from localStorage on mount", () => {
+    localStorage.setItem(
+      "auth",
+      JSON.stringify({ user: "storedUser", token: "storedToken" })
+    );
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    );
+    expect(screen.getByTestId("user").textContent).toBe("storedUser");
+    expect(screen.getByTestId("token").textContent).toBe("storedToken");
+  });
+
+  test("throws error if useAuth is called outside AuthProvider", () => {
+    // Suppress error output for this test
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    function BadComponent() {
+      useAuth();
+      return null;
+    }
+    expect(() => render(<BadComponent />)).toThrow(
+      "useAuth must be used within an AuthProvider"
+    );
+    spy.mockRestore();
+  });
+});

--- a/client/src/context/cart.test.tsx
+++ b/client/src/context/cart.test.tsx
@@ -1,0 +1,101 @@
+import { act, render } from "@testing-library/react";
+import { CartProvider, useCart } from "./cart";
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    clear: () => {
+      store = {};
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+  };
+})();
+(window as any).localStorage = localStorageMock;
+
+const sampleProduct = {
+  _id: "p1",
+  name: "Test Product",
+  price: 10,
+} as any;
+
+function TestComponent() {
+  const [cart, setCart] = useCart();
+  return (
+    <div>
+      <span data-testid="cart-length">{cart.length}</span>
+      <button
+        onClick={() => setCart((prev) => [...prev, sampleProduct])}
+        data-testid="add-btn"
+      >
+        Add
+      </button>
+    </div>
+  );
+}
+
+describe("CartProvider and useCart", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test("initializes cart from localStorage", () => {
+    window.localStorage.setItem("cart", JSON.stringify([sampleProduct]));
+    let cartLength = 0;
+    function ReadCart() {
+      const [cart] = useCart();
+      cartLength = cart.length;
+      return null;
+    }
+    render(
+      <CartProvider>
+        <ReadCart />
+      </CartProvider>
+    );
+    expect(cartLength).toBe(1);
+  });
+
+  test("cart is empty if localStorage is empty", () => {
+    let cartLength = 1;
+    function ReadCart() {
+      const [cart] = useCart();
+      cartLength = cart.length;
+      return null;
+    }
+    render(
+      <CartProvider>
+        <ReadCart />
+      </CartProvider>
+    );
+    expect(cartLength).toBe(0);
+  });
+
+  test("can add item to cart using setCart", () => {
+    const { getByTestId } = render(
+      <CartProvider>
+        <TestComponent />
+      </CartProvider>
+    );
+    expect(getByTestId("cart-length").textContent).toBe("0");
+    act(() => {
+      getByTestId("add-btn").click();
+    });
+    expect(getByTestId("cart-length").textContent).toBe("1");
+  });
+
+  test("throws error if useCart is used outside provider", () => {
+    function BadComponent() {
+      useCart();
+      return null;
+    }
+    expect(() => render(<BadComponent />)).toThrow(
+      "useCart must be used within a CartProvider"
+    );
+  });
+});

--- a/client/src/context/cart.tsx
+++ b/client/src/context/cart.tsx
@@ -1,8 +1,17 @@
 import { createContext, useContext, useEffect, useState } from "react";
+import type { Product } from "../../../models/productModel";
 
-const CartContext = createContext();
-const CartProvider = ({ children }) => {
-  const [cart, setCart] = useState([]);
+export type CartItem = Product;
+
+type CartContextType = [
+  CartItem[],
+  React.Dispatch<React.SetStateAction<CartItem[]>>,
+];
+
+const CartContext = createContext<CartContextType | undefined>(undefined);
+
+const CartProvider = ({ children }: { children: React.ReactNode }) => {
+  const [cart, setCart] = useState<CartItem[]>([]);
 
   useEffect(() => {
     let existingCartItem = localStorage.getItem("cart");
@@ -16,7 +25,13 @@ const CartProvider = ({ children }) => {
   );
 };
 
-// custom hook
-const useCart = () => useContext(CartContext);
+// Custom hook
+const useCart = (): CartContextType => {
+  const context = useContext(CartContext);
+  if (!context) {
+    throw new Error("useCart must be used within a CartProvider");
+  }
+  return context;
+};
 
 export { CartProvider, useCart };

--- a/client/src/context/search.test.tsx
+++ b/client/src/context/search.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
+import { SearchProvider, useSearch } from "./search";
+
+function TestComponent() {
+  const [searchValue, setSearchValue] = useSearch();
+  return (
+    <div>
+      <span data-testid="keyword">{searchValue.keyword}</span>
+      <span data-testid="results">{searchValue.results.length}</span>
+      <button
+        onClick={() => setSearchValue({ keyword: "test", results: [1, 2, 3] })}
+      >
+        Update
+      </button>
+    </div>
+  );
+}
+
+describe("SearchContext", () => {
+  test("provides default values", () => {
+    render(
+      <SearchProvider>
+        <TestComponent />
+      </SearchProvider>
+    );
+    expect(screen.getByTestId("keyword").textContent).toBe("");
+    expect(screen.getByTestId("results").textContent).toBe("0");
+  });
+
+  test("updates context value", async () => {
+    render(
+      <SearchProvider>
+        <TestComponent />
+      </SearchProvider>
+    );
+    const button = screen.getByText("Update");
+    await act(async () => {
+      button.click();
+    });
+    expect(screen.getByTestId("keyword").textContent).toBe("test");
+    expect(screen.getByTestId("results").textContent).toBe("3");
+  });
+
+  test("throws error if useSearch is used outside provider", () => {
+    // Suppress error output for this test
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const BrokenConsumer = () => {
+      useSearch();
+      return null;
+    };
+    expect(() => render(<BrokenConsumer />)).toThrow(
+      "useSearch must be used within a SearchProvider"
+    );
+    spy.mockRestore();
+  });
+});

--- a/client/src/context/search.tsx
+++ b/client/src/context/search.tsx
@@ -1,20 +1,38 @@
 import { createContext, useContext, useState } from "react";
 
-const SearchContext = createContext();
-const SearchProvider = ({ children }) => {
-  const [auth, setAuth] = useState({
+type SearchValue = {
+  keyword: string;
+  // TODO: Define a proper type for results
+  results: any[];
+};
+
+type SearchContextType = [
+  SearchValue,
+  React.Dispatch<React.SetStateAction<SearchValue>>,
+];
+
+const SearchContext = createContext<SearchContextType | undefined>(undefined);
+
+const SearchProvider = ({ children }: { children: React.ReactNode }) => {
+  const [searchValue, setSearchValue] = useState<SearchValue>({
     keyword: "",
     results: [],
   });
 
   return (
-    <SearchContext.Provider value={[auth, setAuth]}>
+    <SearchContext.Provider value={[searchValue, setSearchValue]}>
       {children}
     </SearchContext.Provider>
   );
 };
 
-// custom hook
-const useSearch = () => useContext(SearchContext);
+// Custom hook
+const useSearch = () => {
+  const context = useContext(SearchContext);
+  if (!context) {
+    throw new Error("useSearch must be used within a SearchProvider");
+  }
+  return context;
+};
 
 export { SearchProvider, useSearch };

--- a/client/src/pages/Auth/Register.test.tsx
+++ b/client/src/pages/Auth/Register.test.tsx
@@ -50,7 +50,9 @@ describe("Register Component", () => {
   });
 
   it("should register the user successfully", async () => {
-    axios.post.mockResolvedValueOnce({ data: { success: true } });
+    (axios.post as jest.Mock).mockResolvedValueOnce({
+      data: { success: true },
+    });
 
     const { getByText, getByPlaceholderText } = render(
       <MemoryRouter initialEntries={["/register"]}>

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -6,13 +6,13 @@ import { useNavigate } from "react-router-dom";
 import api from "../api";
 import Layout from "../components/Layout";
 import { Prices } from "../components/Prices";
-import { useCart } from "../context/cart";
+import { CartItem, useCart } from "../context/cart";
 import "../styles/Homepages.css";
 
 const HomePage: React.FC = () => {
   const navigate = useNavigate();
   const [cart, setCart] = useCart();
-  const [products, setProducts] = useState([]);
+  const [products, setProducts] = useState<CartItem[]>([]);
   const [categories, setCategories] = useState([]);
   const [checked, setChecked] = useState([]);
   const [radio, setRadio] = useState([]);
@@ -36,7 +36,8 @@ const HomePage: React.FC = () => {
     getAllCategory();
     getTotal();
   }, []);
-  //get products
+
+  // Get products
   const getAllProducts = async () => {
     try {
       setLoading(true);
@@ -76,7 +77,7 @@ const HomePage: React.FC = () => {
     }
   };
 
-  // filter by cat
+  // Filter by category
   const handleFilter = (value, id) => {
     let all = [...checked];
     if (value) {
@@ -86,6 +87,7 @@ const HomePage: React.FC = () => {
     }
     setChecked(all);
   };
+
   useEffect(() => {
     if (!checked.length || !radio.length) getAllProducts();
   }, [checked.length, radio.length]);
@@ -94,7 +96,7 @@ const HomePage: React.FC = () => {
     if (checked.length || radio.length) filterProduct();
   }, [checked, radio]);
 
-  //get filterd product
+  // Get filtered product
   const filterProduct = async () => {
     try {
       const { data } = await api.product.getProductsWithFilters({
@@ -152,8 +154,8 @@ const HomePage: React.FC = () => {
         <div className="col-md-9 ">
           <h1 className="text-center">All Products</h1>
           <div className="d-flex flex-wrap">
-            {products?.map((p) => (
-              <div className="card m-2" key={p._id}>
+            {products.map((p) => (
+              <div className="card m-2" key={`${p._id}`}>
                 <img
                   src={`/api/v1/product/product-photo/${p._id}`}
                   className="card-img-top"

--- a/controllers/createProductController.test.ts
+++ b/controllers/createProductController.test.ts
@@ -48,8 +48,7 @@ describe("createProductController", () => {
   test("500 when name missing", async () => {
     await createProductController(
       reqOf({ description: "d", price: 10, category: "c", quantity: 1 }),
-      res,
-      undefined as any
+      res
     );
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.send).toHaveBeenCalledWith({ error: "Name is Required" });
@@ -58,8 +57,7 @@ describe("createProductController", () => {
   test("500 when description missing", async () => {
     await createProductController(
       reqOf({ name: "N", price: 10, category: "c", quantity: 1 }),
-      res,
-      undefined as any
+      res
     );
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.send).toHaveBeenCalledWith({
@@ -70,8 +68,7 @@ describe("createProductController", () => {
   test("500 when price missing", async () => {
     await createProductController(
       reqOf({ name: "N", description: "d", category: "c", quantity: 1 }),
-      res,
-      undefined as any
+      res
     );
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.send).toHaveBeenCalledWith({ error: "Price is Required" });
@@ -80,8 +77,7 @@ describe("createProductController", () => {
   test("500 when category missing", async () => {
     await createProductController(
       reqOf({ name: "N", description: "d", price: 1, quantity: 1 }),
-      res,
-      undefined as any
+      res
     );
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.send).toHaveBeenCalledWith({
@@ -92,8 +88,7 @@ describe("createProductController", () => {
   test("500 when quantity missing", async () => {
     await createProductController(
       reqOf({ name: "N", description: "d", price: 1, category: "c" }),
-      res,
-      undefined as any
+      res
     );
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.send).toHaveBeenCalledWith({
@@ -108,8 +103,7 @@ describe("createProductController", () => {
         { name: "N", description: "d", price: 1, category: "c", quantity: 1 },
         { photo: big }
       ),
-      res,
-      undefined as any
+      res
     );
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.send).toHaveBeenCalledWith({
@@ -129,8 +123,7 @@ describe("createProductController", () => {
         quantity: 3,
         shipping: true,
       }),
-      res,
-      undefined as any
+      res
     );
 
     expect(MockProductModel).toHaveBeenCalledWith({
@@ -170,8 +163,7 @@ describe("createProductController", () => {
         },
         { photo }
       ),
-      res,
-      undefined as any
+      res
     );
 
     const instance = MockProductModel.mock.instances[0];
@@ -183,7 +175,7 @@ describe("createProductController", () => {
 
   // ---- Error paths ----
   test("500 when fs.readFileSync throws", async () => {
-    fs.readFileSync.mockImplementationOnce(() => {
+    (fs.readFileSync as jest.Mock).mockImplementationOnce(() => {
       throw new Error("fs fail");
     });
     await createProductController(
@@ -197,8 +189,7 @@ describe("createProductController", () => {
         },
         { photo: { size: 10, path: "p", type: "t" } }
       ),
-      res,
-      undefined as any
+      res
     );
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.send).toHaveBeenCalledWith({
@@ -209,7 +200,7 @@ describe("createProductController", () => {
   });
 
   test("500 when save throws", async () => {
-    fs.readFileSync.mockReturnValueOnce(Buffer.from("IMG"));
+    (fs.readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from("IMG"));
     mockProductSave.mockRejectedValueOnce(new Error("write failed"));
 
     await createProductController(
@@ -223,8 +214,7 @@ describe("createProductController", () => {
         },
         { photo: { size: 10, path: "p", type: "t" } }
       ),
-      res,
-      undefined as any
+      res
     );
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.send).toHaveBeenCalledWith({

--- a/controllers/deleteProductController.test.ts
+++ b/controllers/deleteProductController.test.ts
@@ -19,7 +19,6 @@ jest.mock("braintree", () => {
 describe("deleteProductController", () => {
   let mockReq: any;
   let mockRes: any;
-  let mockNext: any;
 
   beforeEach(() => {
     mockReq = { params: { pid: "123" } };
@@ -28,7 +27,6 @@ describe("deleteProductController", () => {
       send: jest.fn().mockReturnThis(),
       set: jest.fn().mockReturnThis(),
     };
-    mockNext = jest.fn();
 
     jest.clearAllMocks();
   });
@@ -38,7 +36,7 @@ describe("deleteProductController", () => {
       _id: "123",
     });
 
-    await deleteProductController(mockReq, mockRes, mockNext);
+    await deleteProductController(mockReq, mockRes);
 
     expect(productModel.findByIdAndDelete).toHaveBeenCalledWith("123");
     expect(mockRes.status).toHaveBeenCalledWith(200);
@@ -51,7 +49,7 @@ describe("deleteProductController", () => {
   it("should return 404 if product not found", async () => {
     (productModel.findByIdAndDelete as jest.Mock).mockResolvedValue(null);
 
-    await deleteProductController(mockReq, mockRes, mockNext);
+    await deleteProductController(mockReq, mockRes);
 
     expect(productModel.findByIdAndDelete).toHaveBeenCalledWith("123");
     expect(mockRes.status).toHaveBeenCalledWith(404);
@@ -66,7 +64,7 @@ describe("deleteProductController", () => {
       new Error("DB error")
     );
 
-    await deleteProductController(mockReq, mockRes, mockNext);
+    await deleteProductController(mockReq, mockRes);
 
     expect(productModel.findByIdAndDelete).toHaveBeenCalledWith("123");
     expect(mockRes.status).toHaveBeenCalledWith(500);

--- a/controllers/getSingleProductController.test.ts
+++ b/controllers/getSingleProductController.test.ts
@@ -19,7 +19,6 @@ jest.mock("braintree", () => {
 describe("getSingleProductController", () => {
   let mockReq: any;
   let mockRes: any;
-  let mockNext: any;
 
   beforeEach(() => {
     mockReq = { params: { slug: "test-product" } };
@@ -27,7 +26,6 @@ describe("getSingleProductController", () => {
       status: jest.fn().mockReturnThis(),
       send: jest.fn().mockReturnThis(),
     };
-    mockNext = jest.fn();
 
     jest.clearAllMocks();
   });
@@ -40,7 +38,7 @@ describe("getSingleProductController", () => {
       populate: jest.fn().mockReturnThis().mockResolvedValue(mockProduct),
     });
 
-    await getSingleProductController(mockReq, mockRes, mockNext);
+    await getSingleProductController(mockReq, mockRes);
 
     expect(productModel.findOne).toHaveBeenCalledWith({ slug: "test-product" });
     expect(mockRes.status).toHaveBeenCalledWith(200);
@@ -57,7 +55,7 @@ describe("getSingleProductController", () => {
       populate: jest.fn().mockReturnThis().mockResolvedValue(null),
     });
 
-    await getSingleProductController(mockReq, mockRes, mockNext);
+    await getSingleProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(404);
     expect(mockRes.send).toHaveBeenCalledWith({
@@ -75,7 +73,7 @@ describe("getSingleProductController", () => {
         .mockRejectedValue(new Error("DB error")),
     });
 
-    await getSingleProductController(mockReq, mockRes, mockNext);
+    await getSingleProductController(mockReq, mockRes);
 
     expect(productModel.findOne).toHaveBeenCalledWith({ slug: "test-product" });
     expect(mockRes.status).toHaveBeenCalledWith(500);

--- a/controllers/productPhotoController.test.ts
+++ b/controllers/productPhotoController.test.ts
@@ -19,7 +19,6 @@ jest.mock("braintree", () => {
 describe("productPhotoController", () => {
   let mockReq: any;
   let mockRes: any;
-  let mockNext: any;
 
   beforeEach(() => {
     mockReq = { params: { pid: "123" } };
@@ -28,7 +27,6 @@ describe("productPhotoController", () => {
       send: jest.fn().mockReturnThis(),
       set: jest.fn().mockReturnThis(),
     };
-    mockNext = jest.fn();
 
     jest.clearAllMocks();
   });
@@ -46,7 +44,7 @@ describe("productPhotoController", () => {
         .mockResolvedValue({ photo: mockPhoto }),
     });
 
-    await productPhotoController(mockReq, mockRes, mockNext);
+    await productPhotoController(mockReq, mockRes);
 
     expect(productModel.findById).toHaveBeenCalledWith("123");
     expect(mockRes.set).toHaveBeenCalledWith("Content-Type", "image/png");
@@ -59,7 +57,7 @@ describe("productPhotoController", () => {
       select: jest.fn().mockReturnThis().mockResolvedValue(null),
     });
 
-    await productPhotoController(mockReq, mockRes, mockNext);
+    await productPhotoController(mockReq, mockRes);
 
     expect(productModel.findById).toHaveBeenCalledWith("123");
     expect(mockRes.status).toHaveBeenCalledWith(404);
@@ -74,7 +72,7 @@ describe("productPhotoController", () => {
       select: jest.fn().mockReturnThis().mockResolvedValue({ photo: null }),
     });
 
-    await productPhotoController(mockReq, mockRes, mockNext);
+    await productPhotoController(mockReq, mockRes);
 
     expect(productModel.findById).toHaveBeenCalledWith("123");
     expect(mockRes.status).toHaveBeenCalledWith(404);
@@ -94,7 +92,7 @@ describe("productPhotoController", () => {
         }),
     });
 
-    await productPhotoController(mockReq, mockRes, mockNext);
+    await productPhotoController(mockReq, mockRes);
 
     expect(productModel.findById).toHaveBeenCalledWith("123");
     expect(mockRes.status).toHaveBeenCalledWith(404);
@@ -114,7 +112,7 @@ describe("productPhotoController", () => {
         }),
     });
 
-    await productPhotoController(mockReq, mockRes, mockNext);
+    await productPhotoController(mockReq, mockRes);
 
     expect(productModel.findById).toHaveBeenCalledWith("123");
     expect(mockRes.set).toHaveBeenCalledWith(
@@ -133,7 +131,7 @@ describe("productPhotoController", () => {
         .mockRejectedValue(new Error("DB error")),
     });
 
-    await productPhotoController(mockReq, mockRes, mockNext);
+    await productPhotoController(mockReq, mockRes);
 
     expect(productModel.findById).toHaveBeenCalledWith("123");
     expect(mockRes.status).toHaveBeenCalledWith(500);

--- a/controllers/updateProductController.test.ts
+++ b/controllers/updateProductController.test.ts
@@ -23,7 +23,6 @@ jest.mock("braintree", () => {
 describe("updateProductController", () => {
   let mockReq: any;
   let mockRes: any;
-  let mockNext: any;
 
   beforeEach(() => {
     mockReq = {
@@ -44,8 +43,6 @@ describe("updateProductController", () => {
       send: jest.fn().mockReturnThis(),
     };
 
-    mockNext = jest.fn();
-
     jest.clearAllMocks();
   });
 
@@ -58,7 +55,7 @@ describe("updateProductController", () => {
       mockProduct
     );
 
-    await updateProductController(mockReq, mockRes, mockNext);
+    await updateProductController(mockReq, mockRes);
 
     expect(productModel.findByIdAndUpdate).toHaveBeenCalledWith(
       "123",
@@ -85,7 +82,7 @@ describe("updateProductController", () => {
   it("should return 404 if product not found", async () => {
     (productModel.findByIdAndUpdate as jest.Mock).mockResolvedValue(null);
 
-    await updateProductController(mockReq, mockRes, mockNext);
+    await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(404);
     expect(mockRes.send).toHaveBeenCalledWith({
@@ -118,7 +115,7 @@ describe("updateProductController", () => {
     );
     (fs.readFileSync as jest.Mock).mockReturnValue(Buffer.from("data"));
 
-    await updateProductController(mockReq, mockRes, mockNext);
+    await updateProductController(mockReq, mockRes);
 
     expect(fs.readFileSync).toHaveBeenCalledWith("/tmp/photo.jpg");
     expect(mockProduct.photo).toEqual({
@@ -134,7 +131,7 @@ describe("updateProductController", () => {
       new Error("DB Error")
     );
 
-    await updateProductController(mockReq, mockRes, mockNext);
+    await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(500);
     expect(mockRes.send).toHaveBeenCalledWith(
@@ -148,7 +145,7 @@ describe("updateProductController", () => {
   it("should return validation error if name is missing", async () => {
     mockReq.fields.name = "";
 
-    await updateProductController(mockReq, mockRes, mockNext);
+    await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
     expect(mockRes.send).toHaveBeenCalledWith(
@@ -162,7 +159,7 @@ describe("updateProductController", () => {
   it("should return validation error if description is missing", async () => {
     mockReq.fields.description = "";
 
-    await updateProductController(mockReq, mockRes, mockNext);
+    await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
     expect(mockRes.send).toHaveBeenCalledWith(
@@ -176,7 +173,7 @@ describe("updateProductController", () => {
   it("should return validation error if price is missing", async () => {
     mockReq.fields.price = "";
 
-    await updateProductController(mockReq, mockRes, mockNext);
+    await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
     expect(mockRes.send).toHaveBeenCalledWith(
@@ -190,7 +187,7 @@ describe("updateProductController", () => {
   it("should return validation error if category is missing", async () => {
     mockReq.fields.category = "";
 
-    await updateProductController(mockReq, mockRes, mockNext);
+    await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
     expect(mockRes.send).toHaveBeenCalledWith(
@@ -204,7 +201,7 @@ describe("updateProductController", () => {
   it("should return validation error if quantity is missing", async () => {
     mockReq.fields.quantity = "";
 
-    await updateProductController(mockReq, mockRes, mockNext);
+    await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
     expect(mockRes.send).toHaveBeenCalledWith(
@@ -218,7 +215,7 @@ describe("updateProductController", () => {
   it("should return validation error if shipping is undefined", async () => {
     mockReq.fields.shipping = undefined;
 
-    await updateProductController(mockReq, mockRes, mockNext);
+    await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
     expect(mockRes.send).toHaveBeenCalledWith(
@@ -232,7 +229,7 @@ describe("updateProductController", () => {
   it("should return validation error if shipping is null", async () => {
     mockReq.fields.shipping = null;
 
-    await updateProductController(mockReq, mockRes, mockNext);
+    await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
     expect(mockRes.send).toHaveBeenCalledWith(
@@ -250,7 +247,7 @@ describe("updateProductController", () => {
       size: 2000000,
     };
 
-    await updateProductController(mockReq, mockRes, mockNext);
+    await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
     expect(mockRes.send).toHaveBeenCalledWith(

--- a/controllers/updateProductController.test.ts
+++ b/controllers/updateProductController.test.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import fs from "fs";
 import productModel from "../models/productModel";
 import { updateProductController } from "./productController";
@@ -20,29 +21,31 @@ jest.mock("braintree", () => {
 // UpdateProductController
 // =====================================================
 
+const mockRequest = () => {
+  const req: Partial<Request> = {
+    params: { pid: "123" },
+    fields: {
+      name: "Test Product",
+      description: "Desc",
+      price: "100",
+      category: "cat123",
+      quantity: "5",
+      shipping: "true",
+    } as any,
+    files: {},
+  };
+  return req as Request;
+};
+
+const mockResponse = () => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnThis();
+  res.send = jest.fn().mockReturnThis();
+  return res as Response;
+};
+
 describe("updateProductController", () => {
-  let mockReq: any;
-  let mockRes: any;
-
   beforeEach(() => {
-    mockReq = {
-      params: { pid: "123" },
-      fields: {
-        name: "Test Product",
-        description: "Desc",
-        price: "100",
-        category: "cat123",
-        quantity: "5",
-        shipping: "true",
-      },
-      files: {},
-    };
-
-    mockRes = {
-      status: jest.fn().mockReturnThis(),
-      send: jest.fn().mockReturnThis(),
-    };
-
     jest.clearAllMocks();
   });
 
@@ -55,6 +58,8 @@ describe("updateProductController", () => {
       mockProduct
     );
 
+    const mockReq = mockRequest();
+    const mockRes = mockResponse();
     await updateProductController(mockReq, mockRes);
 
     expect(productModel.findByIdAndUpdate).toHaveBeenCalledWith(
@@ -82,6 +87,8 @@ describe("updateProductController", () => {
   it("should return 404 if product not found", async () => {
     (productModel.findByIdAndUpdate as jest.Mock).mockResolvedValue(null);
 
+    const mockReq = mockRequest();
+    const mockRes = mockResponse();
     await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(404);
@@ -97,6 +104,8 @@ describe("updateProductController", () => {
       photo: {} as any,
     };
 
+    const mockReq = mockRequest();
+    const mockRes = mockResponse();
     mockReq.fields = {
       name: "Test",
       description: "Desc",
@@ -104,11 +113,11 @@ describe("updateProductController", () => {
       category: "cat123",
       quantity: "5",
       shipping: "true",
-    };
+    } as any;
 
     mockReq.files = {
       photo: { path: "/tmp/photo.jpg", type: "image/jpeg", size: 500 },
-    };
+    } as any;
 
     (productModel.findByIdAndUpdate as jest.Mock).mockResolvedValue(
       mockProduct
@@ -131,6 +140,8 @@ describe("updateProductController", () => {
       new Error("DB Error")
     );
 
+    const mockReq = mockRequest();
+    const mockRes = mockResponse();
     await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(500);
@@ -143,8 +154,9 @@ describe("updateProductController", () => {
   });
 
   it("should return validation error if name is missing", async () => {
-    mockReq.fields.name = "";
-
+    const mockReq = mockRequest();
+    (mockReq as any).fields.name = "";
+    const mockRes = mockResponse();
     await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -157,8 +169,10 @@ describe("updateProductController", () => {
   });
 
   it("should return validation error if description is missing", async () => {
-    mockReq.fields.description = "";
+    const mockReq = mockRequest();
+    (mockReq as any).fields.description = "";
 
+    const mockRes = mockResponse();
     await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -171,8 +185,10 @@ describe("updateProductController", () => {
   });
 
   it("should return validation error if price is missing", async () => {
-    mockReq.fields.price = "";
+    const mockReq = mockRequest();
+    (mockReq as any).fields.price = "";
 
+    const mockRes = mockResponse();
     await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -185,8 +201,10 @@ describe("updateProductController", () => {
   });
 
   it("should return validation error if category is missing", async () => {
-    mockReq.fields.category = "";
+    const mockReq = mockRequest();
+    (mockReq as any).fields.category = "";
 
+    const mockRes = mockResponse();
     await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -199,8 +217,10 @@ describe("updateProductController", () => {
   });
 
   it("should return validation error if quantity is missing", async () => {
-    mockReq.fields.quantity = "";
+    const mockReq = mockRequest();
+    (mockReq as any).fields.quantity = "";
 
+    const mockRes = mockResponse();
     await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -213,8 +233,10 @@ describe("updateProductController", () => {
   });
 
   it("should return validation error if shipping is undefined", async () => {
-    mockReq.fields.shipping = undefined;
+    const mockReq = mockRequest();
+    (mockReq as any).fields.shipping = undefined;
 
+    const mockRes = mockResponse();
     await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -227,8 +249,10 @@ describe("updateProductController", () => {
   });
 
   it("should return validation error if shipping is null", async () => {
-    mockReq.fields.shipping = null;
+    const mockReq = mockRequest();
+    (mockReq as any).fields.shipping = null;
 
+    const mockRes = mockResponse();
     await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -241,12 +265,14 @@ describe("updateProductController", () => {
   });
 
   it("should return validation error if photo size exceeds 1MB", async () => {
-    mockReq.files.photo = {
+    const mockReq = mockRequest();
+    (mockReq as any).files.photo = {
       path: "/tmp/photo.jpg",
       type: "image/jpeg",
       size: 2000000,
     };
 
+    const mockRes = mockResponse();
     await updateProductController(mockReq, mockRes);
 
     expect(mockRes.status).toHaveBeenCalledWith(400);

--- a/middlewares/authMiddleware.ts
+++ b/middlewares/authMiddleware.ts
@@ -16,7 +16,7 @@ export const requireSignIn: RequestHandler = async (req, res, next) => {
   }
 };
 
-//admin access
+// Admin access
 export const isAdmin: RequestHandler = async (req, res, next) => {
   try {
     const user = await userModel.findById(req.user._id);

--- a/models/productModel.ts
+++ b/models/productModel.ts
@@ -1,6 +1,22 @@
-import mongoose from "mongoose";
+import { model, Schema, type Document, type Types } from "mongoose";
 
-const productSchema = new mongoose.Schema(
+export type Product = Document & {
+  name: string;
+  slug: string;
+  description: string;
+  price: number;
+  category: Types.ObjectId;
+  quantity: number;
+  photo: {
+    data: Buffer;
+    contentType: string;
+  };
+  shipping: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const productSchema = new Schema<Product>(
   {
     name: {
       type: String,
@@ -19,7 +35,7 @@ const productSchema = new mongoose.Schema(
       required: true,
     },
     category: {
-      type: mongoose.ObjectId,
+      type: Schema.Types.ObjectId,
       ref: "Category",
       required: true,
     },
@@ -38,4 +54,4 @@ const productSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-export default mongoose.model("Products", productSchema);
+export default model("Products", productSchema);

--- a/models/userModel.ts
+++ b/models/userModel.ts
@@ -1,6 +1,19 @@
-import mongoose from "mongoose";
+import { Schema, model, type Document } from "mongoose";
 
-const userSchema = new mongoose.Schema(
+export type User = Document & {
+  name: string;
+  email: string;
+  password: string;
+  phone: string;
+  // TODO: Figure out the proper typing for address
+  address: Record<string, any>;
+  answer: string;
+  role: number;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const userSchema = new Schema<User>(
   {
     name: {
       type: String,
@@ -36,4 +49,4 @@ const userSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-export default mongoose.model("users", userSchema);
+export default model("users", userSchema);


### PR DESCRIPTION
Since Jest runs tests in parallel, using global variables:

* Causes potential race conditions
* Is not good TypeScript practice (typing as `any`)
* Makes code harder to reason about and trace (since it breaks immutability)
* (Ab)uses `beforeEach` meant for initialization (e.g. setting up a single connection to a test DB) to reassign mocks instead

By creating the mocks within each test case, not only is it locally scoped thus clearer and also solves all the issues above, but it also follows the AAA principle taught in class.

---

Also adds tests for various contexts and fixes their bugs